### PR TITLE
Fix for Android NDK r11c

### DIFF
--- a/setCrossEnvironment-armeabi-v7a.sh
+++ b/setCrossEnvironment-armeabi-v7a.sh
@@ -7,7 +7,7 @@ IFS='
 
 MYARCH=linux-x86
 if uname -s | grep -i "linux" > /dev/null ; then
-	MYARCH=linux-x86
+	MYARCH=linux-`arch`
 fi
 if uname -s | grep -i "darwin" > /dev/null ; then
 	MYARCH=darwin-x86_64
@@ -19,8 +19,6 @@ fi
 NDK=`which ndk-build`
 NDK=`dirname $NDK`
 #NDK=`readlink -f $NDK`
-
-grep "64.bit" "$NDK/RELEASE.TXT" >/dev/null 2>&1 && MYARCH="${MYARCH}_64"
 
 [ -z "$NDK" ] && { echo "You need Android NDK r8 or newer installed to run this script" ; exit 1 ; }
 GCCPREFIX=arm-linux-androideabi

--- a/setCrossEnvironment-armeabi.sh
+++ b/setCrossEnvironment-armeabi.sh
@@ -5,7 +5,7 @@ IFS='
 
 MYARCH=linux-x86
 if uname -s | grep -i "linux" > /dev/null ; then
-	MYARCH=linux-x86
+	MYARCH=linux-`arch`
 fi
 if uname -s | grep -i "darwin" > /dev/null ; then
 	MYARCH=darwin-x86_64
@@ -17,8 +17,6 @@ fi
 NDK=`which ndk-build`
 NDK=`dirname $NDK`
 #NDK=`readlink -f $NDK`
-
-grep "64.bit" "$NDK/RELEASE.TXT" >/dev/null 2>&1 && MYARCH="${MYARCH}_64"
 
 [ -z "$NDK" ] && { echo "You need Android NDK r8 or newer installed to run this script" ; exit 1 ; }
 GCCPREFIX=arm-linux-androideabi

--- a/setCrossEnvironment-mips.sh
+++ b/setCrossEnvironment-mips.sh
@@ -5,7 +5,7 @@ IFS='
 
 MYARCH=linux-x86
 if uname -s | grep -i "linux" > /dev/null ; then
-	MYARCH=linux-x86
+	MYARCH=linux-`arch`
 fi
 if uname -s | grep -i "darwin" > /dev/null ; then
 	MYARCH=darwin-x86_64
@@ -17,8 +17,6 @@ fi
 NDK=`which ndk-build`
 NDK=`dirname $NDK`
 #NDK=`readlink -f $NDK`
-
-grep "64.bit" "$NDK/RELEASE.TXT" >/dev/null 2>&1 && MYARCH="${MYARCH}_64"
 
 [ -z "$NDK" ] && { echo "You need Android NDK r8 or newer installed to run this script" ; exit 1 ; }
 GCCPREFIX=mipsel-linux-android

--- a/setCrossEnvironment-x86.sh
+++ b/setCrossEnvironment-x86.sh
@@ -5,7 +5,7 @@ IFS='
 
 MYARCH=linux-x86
 if uname -s | grep -i "linux" > /dev/null ; then
-	MYARCH=linux-x86
+	MYARCH=linux-`arch`
 fi
 if uname -s | grep -i "darwin" > /dev/null ; then
 	MYARCH=darwin-x86_64
@@ -17,8 +17,6 @@ fi
 NDK=`which ndk-build`
 NDK=`dirname $NDK`
 #NDK=`readlink -f $NDK`
-
-grep "64.bit" "$NDK/RELEASE.TXT" >/dev/null 2>&1 && MYARCH="${MYARCH}_64"
 
 [ -z "$NDK" ] && { echo "You need Android NDK r8 or newer installed to run this script" ; exit 1 ; }
 GCCPREFIX=i686-linux-android


### PR DESCRIPTION
Seems like `RELEASE.TXT` is gone, so `arch` is now used to determine if we're running on 64bit or not. I'm unsure how to properly check for this on Windows, though.
