### PR TITLE
Add support for x86_64 target.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ armeabi
 armeabi-v7a
 mips
 x86
+x86_64

--- a/README.md
+++ b/README.md
@@ -5,9 +5,16 @@ Port of libiconv and libicu to Android
 
 You will need NDK r10e, curl, autoconf, automake, libtool, and git installed.
 
-There are no sources and no patches - everything is done with magical build scripts,
-just run build.sh and enjoy.
-Don't forget to strip them, because they are huge with debug info included.
+There are no sources and no patches - everything is done with magical build scripts:
+
+(1) Make sure "which ndk-build" shows the correct version to build from
+
+(2) The scripts assume NDK/toolchain/... version 4.9. If otherwise, edit all the *.sh to
+    change GCCVER=4.9 as desired.
+
+(3) Run "./build.sh" and enjoy!
+
+(4) Don't forget to strip them, because they are huge with debug info included.
 
 If you need libintl, you may download it here:
 https://github.com/pelya/commandergenius/tree/sdl_android/project/jni/intl

--- a/build.sh
+++ b/build.sh
@@ -24,7 +24,7 @@ mkdir -p android_support
 cd android_support
 ln -sf $NDK/sources/android/support jni
 
-ndk-build -j$NCPU APP_ABI=$ARCH || exit 1
+ndk-build -j$NCPU APP_ABI=$ARCH LIBCXX_FORCE_REBUILD=true || exit 1
 cp -f obj/local/$ARCH/libandroid_support.a ../
 
 } || exit 1

--- a/build.sh
+++ b/build.sh
@@ -101,7 +101,7 @@ cd $BUILDDIR/$ARCH
 
 	env CFLAGS="-I$NDK/sources/android/support/include -frtti -fexceptions" \
 		LDFLAGS="-frtti -fexceptions" \
-		LIBS="-L$BUILDDIR/$ARCH -landroid_support -lgnustl_static -lstdc++" \
+		LIBS="-L$BUILDDIR/$ARCH -landroid_support -lc++_shared -lstdc++" \
 		$BUILDDIR/setCrossEnvironment-$ARCH.sh \
 		./configure \
 		--host=arm-linux-androideabi \

--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,7 @@ NDK=`which ndk-build`
 NDK=`dirname $NDK`
 NDK=`readlink -f $NDK`
 
-for ARCH in armeabi armeabi-v7a x86 mips; do
+for ARCH in armeabi-v7a; do
 
 cd $BUILDDIR
 mkdir -p $ARCH
@@ -33,7 +33,7 @@ cd $BUILDDIR/$ARCH
 
 # =========== libiconv.so ===========
 
-[ -e libiconv.so ] || {
+true || [ -e libiconv.so ] || {
 
 	[ -e ../libiconv-1.14.tar.gz ] || curl -L http://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.14.tar.gz -o ../libiconv-1.14.tar.gz || exit 1
 
@@ -79,14 +79,14 @@ cd $BUILDDIR/$ARCH
 
 [ -e libicuuc.so ] || {
 
-	[ -e ../icu4c-52_1-src.tgz ] || curl http://pkgs.fedoraproject.org/repo/pkgs/icu/icu4c-52_1-src.tgz/9e96ed4c1d99c0d14ac03c140f9f346c/icu4c-52_1-src.tgz -o ../icu4c-52_1-src.tgz || exit 1
+	[ -e ../icu4c-55_1-src.tgz ] || exit 1
 
-	tar xvf ../icu4c-52_1-src.tgz
+	tar xvf ../icu4c-55_1-src.tgz
 
 	cd icu/source
 
-	cp -f $BUILDDIR/config.sub .
-	cp -f $BUILDDIR/config.guess .
+	#cp -f $BUILDDIR/config.sub .
+	#cp -f $BUILDDIR/config.guess .
 
 	[ -d cross ] || {
 		mkdir cross

--- a/build.sh
+++ b/build.sh
@@ -108,7 +108,6 @@ cd $BUILDDIR/$ARCH
 		--prefix=`pwd`/../../ \
 		--with-cross-build=`pwd`/cross \
 		--enable-static --enable-shared \
-		--with-data-packaging=archive \
 		|| exit 1
 
 	sed -i "s@^prefix *= *.*@prefix = .@" icudefs.mk || exit 1

--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ uname -s | grep -i "linux" && NCPU=`cat /proc/cpuinfo | grep -c -i processor`
 
 NDK=`which ndk-build`
 NDK=`dirname $NDK`
-NDK=`readlink -f $NDK`
+#NDK=`readlink -f $NDK`
 
 for ARCH in armeabi-v7a; do
 
@@ -96,8 +96,8 @@ cd $BUILDDIR/$ARCH
 		cd ..
 	} || exit 1
 
-	sed -i "s@LD_SONAME *=.*@LD_SONAME =@g" config/mh-linux
-	sed -i "s%ln -s *%cp -f \$(dir \$@)/%g" config/mh-linux
+	sed -i.tmp "s@LD_SONAME *=.*@LD_SONAME =@g" config/mh-linux
+	sed -i.tmp "s%ln -s *%cp -f \$(dir \$@)/%g" config/mh-linux
 
 	env CFLAGS="-I$NDK/sources/android/support/include -frtti -fexceptions" \
 		LDFLAGS="-frtti -fexceptions" \
@@ -110,13 +110,13 @@ cd $BUILDDIR/$ARCH
 		--enable-static --enable-shared \
 		|| exit 1
 
-	sed -i "s@^prefix *= *.*@prefix = .@" icudefs.mk || exit 1
+	sed -i.tmp "s@^prefix *= *.*@prefix = .@" icudefs.mk || exit 1
 
 	env PATH=`pwd`:$PATH \
 		$BUILDDIR/setCrossEnvironment-$ARCH.sh \
 		make -j$NCPU VERBOSE=1 || exit 1
 
-	sed -i "s@^prefix *= *.*@prefix = `pwd`/../../@" icudefs.mk || exit 1
+	sed -i.tmp "s@^prefix *= *.*@prefix = `pwd`/../../@" icudefs.mk || exit 1
 
 	env PATH=`pwd`:$PATH \
 		$BUILDDIR/setCrossEnvironment-$ARCH.sh \

--- a/build.sh
+++ b/build.sh
@@ -82,6 +82,7 @@ cd $BUILDDIR/$ARCH
 	[ -e ../icu4c-55_1-src.tgz ] || exit 1
 
 	tar xvf ../icu4c-55_1-src.tgz
+	patch -p0 < ../icu_add_elf_info.patch
 
 	cd icu/source
 

--- a/icu_add_elf_info.patch
+++ b/icu_add_elf_info.patch
@@ -1,0 +1,13 @@
+--- icu/source/tools/toolutil/pkg_genc.c	2015-03-27 21:10:56.000000000 +0000
++++ icu/source/tools/toolutil/pkg_genc.c.patched	2016-08-13 02:21:40.573442401 +0000
+@@ -5,6 +5,10 @@
+  */
+ #include "unicode/utypes.h"
+ 
++#ifndef ELF64_ST_INFO
++#   define ELF64_ST_INFO(bind, type)(((bind) << 4) + ((type) & 0xf))
++#endif
++
+ #if U_PLATFORM_HAS_WIN32_API
+ #   define VC_EXTRALEAN
+ #   define WIN32_LEAN_AND_MEAN

--- a/setCrossEnvironment-armeabi-v7a.sh
+++ b/setCrossEnvironment-armeabi-v7a.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 NDK_STL="libc++"
 
@@ -36,9 +36,11 @@ ARCH=armeabi-v7a
 STL_CFLAGS="-isystem$NDK/sources/cxx-stl/gnu-libstdc++/$GCCVER/include \
 -isystem$NDK/sources/cxx-stl/gnu-libstdc++/$GCCVER/libs/$ARCH/include"
 STL_LDFLAGS="-L$NDK/sources/cxx-stl/gnu-libstdc++/$GCCVER/libs/$ARCH"
-if [[ "$NDK_STL" -eq "libc++" ]] ; then
-	STL_CFLAGS="-isystem$NDK/sources/cxx-stl/llvm-libc++/include"
+STL_LDLIB="-lgnustl_shared -lsupc++"
+if [[ "$NDK_STL" == "libc++" ]] ; then
+	STL_CFLAGS="-isystem$NDK/sources/cxx-stl/llvm-libc++/libcxx/include"
 	STL_LDFLAGS="-L$NDK/sources/cxx-stl/llvm-libc++/libs/$ARCH"
+	STL_LDLIB="-lc++_shared"
 fi
 
 CFLAGS="\
@@ -66,10 +68,9 @@ $SHARED \
 -L$NDK/platforms/$PLATFORMVER/arch-arm/usr/lib \
 -lc -lm -ldl -lz \
 $STL_LDFLAGS \
--lgnustl_static \
+$STL_LDLIB \
 -march=armv7-a -Wl,--fix-cortex-a8 \
 -no-canonical-prefixes $UNRESOLVED -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now \
--lsupc++ \
 $LDFLAGS"
 
 env PATH=$NDK/toolchains/$GCCPREFIX-$GCCVER/prebuilt/$MYARCH/bin:$LOCAL_PATH:$PATH \

--- a/setCrossEnvironment-armeabi-v7a.sh
+++ b/setCrossEnvironment-armeabi-v7a.sh
@@ -10,7 +10,7 @@ if uname -s | grep -i "linux" > /dev/null ; then
 	MYARCH=linux-x86
 fi
 if uname -s | grep -i "darwin" > /dev/null ; then
-	MYARCH=darwin-x86
+	MYARCH=darwin-x86_64
 fi
 if uname -s | grep -i "windows" > /dev/null ; then
 	MYARCH=windows-x86
@@ -18,13 +18,13 @@ fi
 
 NDK=`which ndk-build`
 NDK=`dirname $NDK`
-NDK=`readlink -f $NDK`
+#NDK=`readlink -f $NDK`
 
 grep "64.bit" "$NDK/RELEASE.TXT" >/dev/null 2>&1 && MYARCH="${MYARCH}_64"
 
-[ -z "$NDK" ] && { echo "You need Andorid NDK r8 or newer installed to run this script" ; exit 1 ; }
+[ -z "$NDK" ] && { echo "You need Android NDK r8 or newer installed to run this script" ; exit 1 ; }
 GCCPREFIX=arm-linux-androideabi
-GCCVER=4.8
+GCCVER=4.9
 PLATFORMVER=android-16
 LOCAL_PATH=`dirname $0`
 if which realpath > /dev/null ; then

--- a/setCrossEnvironment-armeabi-v7a.sh
+++ b/setCrossEnvironment-armeabi-v7a.sh
@@ -7,7 +7,7 @@ IFS='
 
 MYARCH=linux-x86
 if uname -s | grep -i "linux" > /dev/null ; then
-	MYARCH=linux-x86
+	MYARCH=linux-`arch`
 fi
 if uname -s | grep -i "darwin" > /dev/null ; then
 	MYARCH=darwin-x86_64
@@ -19,8 +19,6 @@ fi
 NDK=`which ndk-build`
 NDK=`dirname $NDK`
 #NDK=`readlink -f $NDK`
-
-grep "64.bit" "$NDK/RELEASE.TXT" >/dev/null 2>&1 && MYARCH="${MYARCH}_64"
 
 [ -z "$NDK" ] && { echo "You need Android NDK r8 or newer installed to run this script" ; exit 1 ; }
 GCCPREFIX=arm-linux-androideabi

--- a/setCrossEnvironment-armeabi.sh
+++ b/setCrossEnvironment-armeabi.sh
@@ -8,7 +8,7 @@ if uname -s | grep -i "linux" > /dev/null ; then
 	MYARCH=linux-x86
 fi
 if uname -s | grep -i "darwin" > /dev/null ; then
-	MYARCH=darwin-x86
+	MYARCH=darwin-x86_64
 fi
 if uname -s | grep -i "windows" > /dev/null ; then
 	MYARCH=windows-x86
@@ -16,13 +16,13 @@ fi
 
 NDK=`which ndk-build`
 NDK=`dirname $NDK`
-NDK=`readlink -f $NDK`
+#NDK=`readlink -f $NDK`
 
 grep "64.bit" "$NDK/RELEASE.TXT" >/dev/null 2>&1 && MYARCH="${MYARCH}_64"
 
-[ -z "$NDK" ] && { echo "You need Andorid NDK r8 or newer installed to run this script" ; exit 1 ; }
+[ -z "$NDK" ] && { echo "You need Android NDK r8 or newer installed to run this script" ; exit 1 ; }
 GCCPREFIX=arm-linux-androideabi
-GCCVER=4.8
+GCCVER=4.9
 PLATFORMVER=android-14
 LOCAL_PATH=`dirname $0`
 if which realpath > /dev/null ; then

--- a/setCrossEnvironment-armeabi.sh
+++ b/setCrossEnvironment-armeabi.sh
@@ -5,7 +5,7 @@ IFS='
 
 MYARCH=linux-x86
 if uname -s | grep -i "linux" > /dev/null ; then
-	MYARCH=linux-x86
+	MYARCH=linux-`arch`
 fi
 if uname -s | grep -i "darwin" > /dev/null ; then
 	MYARCH=darwin-x86_64
@@ -17,8 +17,6 @@ fi
 NDK=`which ndk-build`
 NDK=`dirname $NDK`
 #NDK=`readlink -f $NDK`
-
-grep "64.bit" "$NDK/RELEASE.TXT" >/dev/null 2>&1 && MYARCH="${MYARCH}_64"
 
 [ -z "$NDK" ] && { echo "You need Android NDK r8 or newer installed to run this script" ; exit 1 ; }
 GCCPREFIX=arm-linux-androideabi

--- a/setCrossEnvironment-mips.sh
+++ b/setCrossEnvironment-mips.sh
@@ -5,7 +5,7 @@ IFS='
 
 MYARCH=linux-x86
 if uname -s | grep -i "linux" > /dev/null ; then
-	MYARCH=linux-x86
+	MYARCH=linux-`arch`
 fi
 if uname -s | grep -i "darwin" > /dev/null ; then
 	MYARCH=darwin-x86_64
@@ -17,8 +17,6 @@ fi
 NDK=`which ndk-build`
 NDK=`dirname $NDK`
 #NDK=`readlink -f $NDK`
-
-grep "64.bit" "$NDK/RELEASE.TXT" >/dev/null 2>&1 && MYARCH="${MYARCH}_64"
 
 [ -z "$NDK" ] && { echo "You need Android NDK r8 or newer installed to run this script" ; exit 1 ; }
 GCCPREFIX=mipsel-linux-android

--- a/setCrossEnvironment-mips.sh
+++ b/setCrossEnvironment-mips.sh
@@ -8,7 +8,7 @@ if uname -s | grep -i "linux" > /dev/null ; then
 	MYARCH=linux-x86
 fi
 if uname -s | grep -i "darwin" > /dev/null ; then
-	MYARCH=darwin-x86
+	MYARCH=darwin-x86_64
 fi
 if uname -s | grep -i "windows" > /dev/null ; then
 	MYARCH=windows-x86
@@ -16,13 +16,13 @@ fi
 
 NDK=`which ndk-build`
 NDK=`dirname $NDK`
-NDK=`readlink -f $NDK`
+#NDK=`readlink -f $NDK`
 
 grep "64.bit" "$NDK/RELEASE.TXT" >/dev/null 2>&1 && MYARCH="${MYARCH}_64"
 
-[ -z "$NDK" ] && { echo "You need Andorid NDK r8 or newer installed to run this script" ; exit 1 ; }
+[ -z "$NDK" ] && { echo "You need Android NDK r8 or newer installed to run this script" ; exit 1 ; }
 GCCPREFIX=mipsel-linux-android
-GCCVER=4.8
+GCCVER=4.9
 PLATFORMVER=android-14
 LOCAL_PATH=`dirname $0`
 if which realpath > /dev/null ; then

--- a/setCrossEnvironment-x86.sh
+++ b/setCrossEnvironment-x86.sh
@@ -5,7 +5,7 @@ IFS='
 
 MYARCH=linux-x86
 if uname -s | grep -i "linux" > /dev/null ; then
-	MYARCH=linux-x86
+	MYARCH=linux-`arch`
 fi
 if uname -s | grep -i "darwin" > /dev/null ; then
 	MYARCH=darwin-x86_64
@@ -17,8 +17,6 @@ fi
 NDK=`which ndk-build`
 NDK=`dirname $NDK`
 #NDK=`readlink -f $NDK`
-
-grep "64.bit" "$NDK/RELEASE.TXT" >/dev/null 2>&1 && MYARCH="${MYARCH}_64"
 
 [ -z "$NDK" ] && { echo "You need Android NDK r8 or newer installed to run this script" ; exit 1 ; }
 GCCPREFIX=i686-linux-android

--- a/setCrossEnvironment-x86.sh
+++ b/setCrossEnvironment-x86.sh
@@ -8,7 +8,7 @@ if uname -s | grep -i "linux" > /dev/null ; then
 	MYARCH=linux-x86
 fi
 if uname -s | grep -i "darwin" > /dev/null ; then
-	MYARCH=darwin-x86
+	MYARCH=darwin-x86_64
 fi
 if uname -s | grep -i "windows" > /dev/null ; then
 	MYARCH=windows-x86
@@ -16,13 +16,13 @@ fi
 
 NDK=`which ndk-build`
 NDK=`dirname $NDK`
-NDK=`readlink -f $NDK`
+#NDK=`readlink -f $NDK`
 
 grep "64.bit" "$NDK/RELEASE.TXT" >/dev/null 2>&1 && MYARCH="${MYARCH}_64"
 
-[ -z "$NDK" ] && { echo "You need Andorid NDK r8 or newer installed to run this script" ; exit 1 ; }
+[ -z "$NDK" ] && { echo "You need Android NDK r8 or newer installed to run this script" ; exit 1 ; }
 GCCPREFIX=i686-linux-android
-GCCVER=4.8
+GCCVER=4.9
 PLATFORMVER=android-14
 LOCAL_PATH=`dirname $0`
 if which realpath > /dev/null ; then

--- a/setCrossEnvironment-x86_64.sh
+++ b/setCrossEnvironment-x86_64.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+NDK_STL="libc++"
+
+IFS='
+'
+
+MYARCH=linux-x86_64
+if uname -s | grep -i "linux" > /dev/null ; then
+	MYARCH=linux-`arch`
+fi
+if uname -s | grep -i "darwin" > /dev/null ; then
+	MYARCH=darwin-x86_64
+fi
+if uname -s | grep -i "windows" > /dev/null ; then
+	MYARCH=windows-x86
+fi
+
+NDK=`which ndk-build`
+NDK=`dirname $NDK`
+#NDK=`readlink -f $NDK`
+
+[ -z "$NDK" ] && { echo "You need Android NDK r8 or newer installed to run this script" ; exit 1 ; }
+GCCPREFIX=x86_64-linux-android
+GCCVER=4.9
+PLATFORMVER=android-21
+LOCAL_PATH=`dirname $0`
+if which realpath > /dev/null ; then
+	LOCAL_PATH=`realpath $LOCAL_PATH`
+else
+	LOCAL_PATH=`cd $LOCAL_PATH && pwd`
+fi
+ARCH=x86_64
+
+STL_CFLAGS="-isystem$NDK/sources/cxx-stl/gnu-libstdc++/$GCCVER/include \
+-isystem$NDK/sources/cxx-stl/gnu-libstdc++/$GCCVER/libs/$ARCH/include"
+STL_LDFLAGS="-L$NDK/sources/cxx-stl/gnu-libstdc++/$GCCVER/libs/$ARCH"
+STL_LDLIB="-lgnustl_shared -lsupc++"
+if [[ "$NDK_STL" == "libc++" ]] ; then
+        STL_CFLAGS="-isystem$NDK/sources/cxx-stl/llvm-libc++/libcxx/include"
+        STL_LDFLAGS="-L$NDK/sources/cxx-stl/llvm-libc++/libs/$ARCH"
+        STL_LDLIB="-lc++_shared"
+fi
+
+
+CFLAGS="\
+-ffunction-sections -funwind-tables -no-canonical-prefixes \
+-fstack-protector -O2 -g -DNDEBUG \
+-fomit-frame-pointer -fstrict-aliasing -funswitch-loops \
+-finline-limit=300 \
+-DANDROID -Wall -Wno-unused -Wa,--noexecstack -Wformat -Werror=format-security \
+-isystem$NDK/platforms/$PLATFORMVER/arch-x86_64/usr/include \
+$STL_CFLAGS \
+$CFLAGS"
+
+UNRESOLVED="-Wl,--no-undefined"
+SHARED="-Wl,--gc-sections -Wl,-z,nocopyreloc"
+if [ -n "$BUILD_LIBRARY" ]; then
+	[ -z "$SHARED_LIBRARY_NAME" ] && SHARED_LIBRARY_NAME=libapplication.so
+	SHARED="-shared -Wl,-soname,$SHARED_LIBRARY_NAME"
+fi
+if [ -n "$ALLOW_UNRESOLVED_SYMBOLS" ]; then
+	UNRESOLVED=
+fi
+
+LDFLAGS="\
+$SHARED \
+--sysroot=$NDK/platforms/$PLATFORMVER/arch-x86_64 \
+-L$NDK/platforms/$PLATFORMVER/arch-x86_64/usr/lib64 \
+-lc -lm -ldl -lz \
+$STL_LDFLAGS \
+$STL_LDLIB \
+-no-canonical-prefixes $UNRESOLVED -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now \
+$LDFLAGS"
+
+env PATH=$NDK/toolchains/$ARCH-$GCCVER/prebuilt/$MYARCH/bin:$LOCAL_PATH:$PATH \
+CFLAGS="$CFLAGS" \
+CXXFLAGS="$CXXFLAGS $CFLAGS" \
+LDFLAGS="$LDFLAGS" \
+CC="$NDK/toolchains/$ARCH-$GCCVER/prebuilt/$MYARCH/bin/$GCCPREFIX-gcc" \
+CXX="$NDK/toolchains/$ARCH-$GCCVER/prebuilt/$MYARCH/bin/$GCCPREFIX-g++" \
+RANLIB="$NDK/toolchains/$ARCH-$GCCVER/prebuilt/$MYARCH/bin/$GCCPREFIX-ranlib" \
+LD="$NDK/toolchains/$ARCH-$GCCVER/prebuilt/$MYARCH/bin/$GCCPREFIX-ld" \
+AR="$NDK/toolchains/$ARCH-$GCCVER/prebuilt/$MYARCH/bin/$GCCPREFIX-ar" \
+CPP="$NDK/toolchains/$ARCH-$GCCVER/prebuilt/$MYARCH/bin/$GCCPREFIX-cpp $CFLAGS" \
+CXXCPP="$NDK/toolchains/$ARCH-$GCCVER/prebuilt/$MYARCH/bin/$GCCPREFIX-cpp -x c++ $CFLAGS" \
+NM="$NDK/toolchains/$ARCH-$GCCVER/prebuilt/$MYARCH/bin/$GCCPREFIX-nm" \
+AS="$NDK/toolchains/$ARCH-$GCCVER/prebuilt/$MYARCH/bin/$GCCPREFIX-as" \
+STRIP="$NDK/toolchains/$ARCH-$GCCVER/prebuilt/$MYARCH/bin/$GCCPREFIX-strip" \
+"$@"


### PR DESCRIPTION
This change adds support to x86_64 and Android Platform >= 21.

Now `build.sh` receives a list of platforms to be build. However, the script remains compatible with the current usage, building `armeabi-v7a` if no parameter is passed.

```
# USAGE: ./build.sh [arch1=optional] [arch2=optional] ...
# arch1 = defaults to armeabi-v7a if empty
# arch* = armeabi-v7a|armeabi|mips|x86|x86_64
# arch* = only armeabi-v7a and x86_64 are tested and known to be working by now
```

Also, Android Platform >= 21 lacks of `exec_elf.h` file, previously located in `/android-ndk-?/platforms/android-(<=19)/arch-?/usr/include/sys/exec_elf.h`. `icu/source/tools/toolutil/pkg_genc.c` has a reference to the `ELF64_ST_INFO` macro in order to create the symbol table for ELF32 and ELF64 used by `writeObjectCode`. I'm applying as a patch the definition of that macro only if necessary. The definition of the macro is the same in `arm`, `mips`, `x86` and `x86_64`, so there should be no conflict.

I hope you find the contribution useful, I'm trying to compile swift for `x86_64-linux-android` in order to run some tests in a simulator and this is one of the things I needed to do so. Let me know if you want me to change something in order to improve the PR.

Thanks.
