### PR TITLE
Add an ENVVAR to append a suffix to the lib names.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -77,11 +77,17 @@ cd $BUILDDIR/$ARCH
 
 # =========== libicuXX.so ===========
 
-[ -e libicuuc.so ] || {
+[ -e libicuuc$LIBSUFFIX.so ] || {
 
 	[ -e ../icu4c-55_1-src.tgz ] || exit 1
 
 	tar xvf ../icu4c-55_1-src.tgz
+
+	# The ENVVAR LIBSUFFIX should add the suffix only to the libname and not to the symbols.
+	# ToDo: Find the right way in Swift to refer to an alternative library with symbol prefixing or any other method to remove this.
+	if $[ -n "$LIBSUFFIX" ]; then
+		patch -p0 < ../patches/icu_suffix_only_on_libname.patch
+	fi
 
 	cd icu/source
 
@@ -104,6 +110,7 @@ cd $BUILDDIR/$ARCH
 		./configure \
 		--host=arm-linux-androideabi \
 		--prefix=`pwd`/../../ \
+		--with-library-suffix=$LIBSUFFIX \
 		--with-cross-build=`pwd`/cross \
 		--enable-static --enable-shared \
 		|| exit 1
@@ -119,7 +126,7 @@ cd $BUILDDIR/$ARCH
 		$BUILDDIR/setCrossEnvironment-$ARCH.sh \
 		make V=1 install || exit 1
 
-	for f in libicudata libicutest libicui18n libicuio libicule libiculx libicutu libicuuc; do
+	for f in libicudata$LIBSUFFIX libicutest$LIBSUFFIX libicui18n$LIBSUFFIX libicuio$LIBSUFFIX libicule$LIBSUFFIX libiculx$LIBSUFFIX libicutu$LIBSUFFIX libicuuc$LIBSUFFIX; do
 		cp -f -H ../../lib/$f.so ../../
 		cp -f ../../lib/$f.a ../../
 		$BUILDDIR/setCrossEnvironment-$ARCH.sh \

--- a/patches/icu_suffix_only_on_libname.patch
+++ b/patches/icu_suffix_only_on_libname.patch
@@ -1,0 +1,18 @@
+--- icu/source/configure	2013-05-23 20:06:32.000000000 +0000
++++ icu/source/configure.patched	2018-02-21 23:35:25.934967613 +0000
+@@ -7217,14 +7217,7 @@
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: $msg" >&5
+ $as_echo "$msg" >&6; }
+ 
+-if test "$ICULIBSUFFIX" != ""
+-then
+-    U_HAVE_LIB_SUFFIX=1
+-    ICULIBSUFFIXCNAME=`echo _$ICULIBSUFFIX | sed 's/^A-Za-z0-9_/_/g'`
+-    UCONFIG_CPPFLAGS="${UCONFIG_CPPFLAGS} -DU_HAVE_LIB_SUFFIX=1 -DU_LIB_SUFFIX_C_NAME=${ICULIBSUFFIXCNAME} "
+-else
+-    U_HAVE_LIB_SUFFIX=0
+-fi
++U_HAVE_LIB_SUFFIX=0
+ 
+ 
+ 


### PR DESCRIPTION
Swift is expecting this libraries to be named `icuucswift` for Android to avoid name collision with Android's `icuuc`.

This should be temporal, a more appropriate solution (if any) should be applied to solve this lib conflict.

With this patch now the expected set of libraries can be created by just calling `env LIBSUFFIX=swift ./build.sh`, avoiding a complicated set of setps detailed in Swift's `Android.md`. If this or any other change to reduce the impact of this requirement is merged I'll update the docs in `Android.md`.

The change is additive, when used as before (just calling `build.sh`) it shouldn't produce any different outcome.