### PR TITLE
Build aarch64 for Swift by default

### DIFF
--- a/build-swift.sh
+++ b/build-swift.sh
@@ -1,1 +1,2 @@
-SKIP_HARFBUZZ=1 SHARED_ICU=1 SKIP_ICONV=1 ARCHS='armeabi-v7a' LIBSUFFIX=swift ./build.sh
+#! /usr/bin/env sh
+SKIP_HARFBUZZ=1 SHARED_ICU=1 SKIP_ICONV=1 ARCHS='armeabi-v7a arm64-v8a' LIBSUFFIX=swift ./build.sh


### PR DESCRIPTION
It also adds the missing shebang.