### PR TITLE
Remove libandroid_support from 64 bits targets.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -36,21 +36,6 @@ echo "ARCH $ARCH GCCPREFIX $GCCPREFIX"
 mkdir -p $ARCH
 cd $BUILDDIR/$ARCH
 
-# =========== libandroid_support.a ===========
-
-[ -e libandroid_support.a ] || {
-	mkdir -p android_support
-	cd android_support
-	ln -sf $NDK/sources/android/support jni
-
-	#ndk-build -j$NCPU APP_ABI=$ARCH APP_MODULES=android_support LIBCXX_FORCE_REBUILD=true CLANG=1 || exit 1
-	#cp -f obj/local/$ARCH/libandroid_support.a ../
-	ln -sf $NDK/sources/cxx-stl/llvm-libc++/libs/$ARCH/libandroid_support.a ../
-
-} || exit 1
-
-cd $BUILDDIR/$ARCH
-
 # =========== libiconv.so ===========
 
 [ -e libiconv.so ] || [ $SKIP_ICONV ] || {
@@ -209,7 +194,7 @@ cd $BUILDDIR/$ARCH
 
 	env CFLAGS="-I$NDK/sources/android/support/include -frtti -fexceptions" \
 		LDFLAGS="-frtti -fexceptions -L$BUILDDIR/$ARCH/lib" \
-		LIBS="-L$BUILDDIR/$ARCH -landroid_support `$BUILDDIR/setCrossEnvironment-$ARCH.sh sh -c 'echo $LDFLAGS'`" \
+		LIBS="-L$BUILDDIR/$ARCH `$BUILDDIR/setCrossEnvironment-$ARCH.sh sh -c 'echo $LDFLAGS'`" \
 		env ac_cv_func_strtod_l=no \
 		$BUILDDIR/setCrossEnvironment-$ARCH.sh \
 		./configure \
@@ -360,7 +345,7 @@ cd $BUILDDIR/$ARCH
 
 	env CFLAGS="-I$NDK/sources/android/support/include -frtti -fexceptions" \
 		LDFLAGS="-frtti -fexceptions -L$BUILDDIR/$ARCH/lib" \
-		LIBS="-L$BUILDDIR/$ARCH -landroid_support `$BUILDDIR/setCrossEnvironment-$ARCH.sh sh -c 'echo $LDFLAGS'`" \
+		LIBS="-L$BUILDDIR/$ARCH `$BUILDDIR/setCrossEnvironment-$ARCH.sh sh -c 'echo $LDFLAGS'`" \
 		ICULEHB_CFLAGS="-I$BUILDDIR/$ARCH/include/icu-le-hb" \
 		ICULEHB_LIBS="-licu-le-hb" \
 		$BUILDDIR/setCrossEnvironment-$ARCH.sh \

--- a/setCrossEnvironment-arm64-v8a.sh
+++ b/setCrossEnvironment-arm64-v8a.sh
@@ -60,12 +60,19 @@ $CFLAGS"
 
 CFLAGS="`echo $CFLAGS | tr '\n' ' '`"
 
+LIBANDROID_SUPPORT_PATH=$NDK/sources/android/support/../../cxx-stl/llvm-libc++/libs/arm64-v8a/libandroid_support.a
+if [ -f $LIBANDROID_SUPPORT_PATH ] ; then
+	LIBANDROID_SUPPORT_LDFLAG=$LIBANDROID_SUPPORT_PATH
+else
+	LIBANDROID_SUPPORT_LDFLAG=
+fi
+
 LDFLAGS="
 -shared
 --sysroot $NDK/platforms/android-21/arch-arm64
 $NDK/sources/cxx-stl/llvm-libc++/libs/arm64-v8a/libc++_static.a
 $NDK/sources/cxx-stl/llvm-libc++abi/../llvm-libc++/libs/arm64-v8a/libc++abi.a
-$NDK/sources/android/support/../../cxx-stl/llvm-libc++/libs/arm64-v8a/libandroid_support.a
+$LIBANDROID_SUPPORT_LDFLAG
 -latomic -Wl,--exclude-libs,libatomic.a
 -gcc-toolchain $NDK/toolchains/aarch64-linux-android-4.9/prebuilt/linux-x86_64
 -target aarch64-none-linux-android -no-canonical-prefixes

--- a/setCrossEnvironment-armeabi-v7a.sh
+++ b/setCrossEnvironment-armeabi-v7a.sh
@@ -65,12 +65,19 @@ $CFLAGS"
 
 CFLAGS="`echo $CFLAGS | tr '\n' ' '`"
 
+LIBANDROID_SUPPORT_PATH=$NDK/sources/android/support/../../cxx-stl/llvm-libc++/libs/armeabi-v7a/libandroid_support.a
+if [ -f $LIBANDROID_SUPPORT_PATH ] ; then
+	LIBANDROID_SUPPORT_LDFLAG=$LIBANDROID_SUPPORT_PATH
+else
+	LIBANDROID_SUPPORT_LDFLAG=
+fi
+
 LDFLAGS="
 -shared
 --sysroot $NDK/platforms/android-14/arch-arm
 $NDK/sources/cxx-stl/llvm-libc++/libs/armeabi-v7a/libc++_static.a
 $NDK/sources/cxx-stl/llvm-libc++abi/../llvm-libc++/libs/armeabi-v7a/libc++abi.a
-$NDK/sources/android/support/../../cxx-stl/llvm-libc++/libs/armeabi-v7a/libandroid_support.a
+$LIBANDROID_SUPPORT_LDFLAG
 $NDK/sources/cxx-stl/llvm-libc++/libs/armeabi-v7a/libunwind.a
 -latomic -Wl,--exclude-libs,libatomic.a
 -gcc-toolchain

--- a/setCrossEnvironment-armeabi.sh
+++ b/setCrossEnvironment-armeabi.sh
@@ -65,12 +65,19 @@ $CFLAGS"
 
 CFLAGS="`echo $CFLAGS | tr '\n' ' '`"
 
+LIBANDROID_SUPPORT_PATH=$NDK/sources/android/support/../../cxx-stl/llvm-libc++/libs/armeabi/libandroid_support.a
+if [ -f $LIBANDROID_SUPPORT_PATH ] ; then
+	LIBANDROID_SUPPORT_LDFLAG=$LIBANDROID_SUPPORT_PATH
+else
+	LIBANDROID_SUPPORT_LDFLAG=
+fi
+
 LDFLAGS="
 -shared
 --sysroot $NDK/platforms/android-14/arch-arm
 $NDK/sources/cxx-stl/llvm-libc++/libs/armeabi/libc++_static.a
 $NDK/sources/cxx-stl/llvm-libc++abi/../llvm-libc++/libs/armeabi/libc++abi.a
-$NDK/sources/android/support/../../cxx-stl/llvm-libc++/libs/armeabi/libandroid_support.a
+$LIBANDROID_SUPPORT_LDFLAG
 $NDK/sources/cxx-stl/llvm-libc++/libs/armeabi/libunwind.a
 -latomic -Wl,--exclude-libs,libatomic.a
 -gcc-toolchain

--- a/setCrossEnvironment-x86.sh
+++ b/setCrossEnvironment-x86.sh
@@ -61,12 +61,19 @@ $CFLAGS"
 
 CFLAGS="`echo $CFLAGS | tr '\n' ' '`"
 
+LIBANDROID_SUPPORT_PATH=$NDK/sources/android/support/../../cxx-stl/llvm-libc++/libs/x86/libandroid_support.a
+if [ -f $LIBANDROID_SUPPORT_PATH ] ; then
+	LIBANDROID_SUPPORT_LDFLAG=$LIBANDROID_SUPPORT_PATH
+else
+	LIBANDROID_SUPPORT_LDFLAG=
+fi
+
 LDFLAGS="
 -shared
 --sysroot $NDK/platforms/android-14/arch-x86
 $NDK/sources/cxx-stl/llvm-libc++/libs/x86/libc++_static.a
 $NDK/sources/cxx-stl/llvm-libc++abi/../llvm-libc++/libs/x86/libc++abi.a
-$NDK/sources/android/support/../../cxx-stl/llvm-libc++/libs/x86/libandroid_support.a
+$LIBANDROID_SUPPORT_LDFLAG
 -latomic -Wl,--exclude-libs,libatomic.a
 -gcc-toolchain
 $NDK/toolchains/x86-4.9/prebuilt/linux-x86_64

--- a/setCrossEnvironment-x86_64.sh
+++ b/setCrossEnvironment-x86_64.sh
@@ -60,12 +60,19 @@ $CFLAGS"
 
 CFLAGS="`echo $CFLAGS | tr '\n' ' '`"
 
+LIBANDROID_SUPPORT_PATH=$NDK/sources/android/support/../../cxx-stl/llvm-libc++/libs/x86_64/libandroid_support.a
+if [ -f $LIBANDROID_SUPPORT_PATH ] ; then
+	LIBANDROID_SUPPORT_LDFLAG=$LIBANDROID_SUPPORT_PATH
+else
+	LIBANDROID_SUPPORT_LDFLAG=
+fi
+
 LDFLAGS="
 -shared
 --sysroot $NDK/platforms/android-21/arch-x86_64
 $NDK/sources/cxx-stl/llvm-libc++/libs/x86_64/libc++_static.a
 $NDK/sources/cxx-stl/llvm-libc++abi/../llvm-libc++/libs/x86_64/libc++abi.a
-$NDK/sources/android/support/../../cxx-stl/llvm-libc++/libs/x86_64/libandroid_support.a
+$LIBANDROID_SUPPORT_LDFLAG
 -latomic -Wl,--exclude-libs,libatomic.a
 -gcc-toolchain
 $NDK/toolchains/x86_64-4.9/prebuilt/linux-x86_64


### PR DESCRIPTION
libandroid_support is not supported in 64 bits targets in NDK
version 17 and 18, so trying to copy and link against it is not
necessary.

The change removes the copying of libandroid_support.a into the
result directory (which doesn't seem to be used for anything) and
moves the -landroid_support flag out of build.sh and into the
setCrossEnvironment files for 32 bits platforms.